### PR TITLE
Ability for users to choice on which server they would receive the reward

### DIFF
--- a/assets/js/vote.js
+++ b/assets/js/vote.js
@@ -81,6 +81,7 @@ function refreshVote(url) {
     setTimeout(function () {
         axios.post(url + '/done', {
             user: username,
+            server_id: document.getElementById('stepServerIdInput').value
         }).then(function (response) {
             if (response.data.status === 'pending') {
                 refreshVote(url);
@@ -97,3 +98,33 @@ function refreshVote(url) {
         });
     }, 5000);
 }
+
+function selectSite() {
+
+    document.querySelectorAll("a[data-server-id]").forEach(function (elem) {
+
+        let arrayContains = function (toCompare, array) {
+            let contains = false;
+            array.forEach(value => {
+                if (value == toCompare) {
+                    contains = true;
+                }
+            })
+            return contains;
+        };
+
+        if (arrayContains(document.getElementById('stepServerIdInput').value, JSON.parse(elem.dataset.serverId))) {
+            elem.hidden = false;
+        } else {
+            elem.hidden = true;
+        }
+    })
+}
+
+document.getElementById('stepServerIdInput').addEventListener('change', function() {
+    selectSite();
+});
+
+(function () {
+    selectSite();
+})()

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -28,8 +28,18 @@
                     <div class="spinner-border text-white" role="status"></div>
                 </div>
 
+                    @if (count($servers) > 1)
+                    <select id="stepServerIdInput">
+                        @foreach($servers as $id => $name)
+                            <option value="{{ $id }}">{{ $name }}</option>
+                        @endforeach
+                    </select>
+                    @else
+                    <input type="hidden" id="stepServerIdInput" value="{{ array_key_first($servers) }}">
+                    @endif
+
                 @forelse($sites as $site)
-                    <a class="btn btn-primary" href="{{ $site->url }}" target="_blank" rel="noopener noreferrer" data-site-url="{{ route('vote.vote', $site) }}">{{ $site->name }}</a>
+                    <a class="btn btn-primary" href="{{ $site->url }}" target="_blank" rel="noopener noreferrer" data-server-id='{{ $site->getServersAsJson() }}' data-site-url="{{ route('vote.vote', $site) }}">{{ $site->name }}</a>
                 @empty
                     <div class="alert alert-warning" role="alert">{{ trans('vote::messages.no-site') }}</div>
                 @endforelse

--- a/src/Models/Site.php
+++ b/src/Models/Site.php
@@ -68,14 +68,33 @@ class Site extends Model
         return $this->hasMany(Vote::class);
     }
 
-    public function getRandomReward()
+    public function getServersAsJson() {
+
+        $serversId = [];
+        foreach ($this->rewards as $reward) {
+            $serversId[] = $reward->server_id;
+        }
+
+        return json_encode($serversId);
+    }
+
+    public function getRandomReward(int $server_id = null)
     {
-        $total = $this->rewards->sum('chances');
+
+        $rewards = clone $this->rewards;
+
+        if ($server_id !== null) {
+            $rewards = $rewards->filter(function($reward) use ($server_id) {
+                return $reward->server_id === $server_id;
+            });
+        }
+
+        $total = $rewards->sum('chances');
         $random = random_int(0, $total);
 
         $sum = 0;
 
-        foreach ($this->rewards as $reward) {
+        foreach ($rewards as $reward) {
             $sum += $reward->chances;
 
             if ($sum >= $random) {
@@ -83,7 +102,7 @@ class Site extends Model
             }
         }
 
-        return $this->rewards->first();
+        return $rewards->first();
     }
 
     public function getNextVoteTime(User $user, Request $request)


### PR DESCRIPTION
As a server administrator, I can configure a reward X for my server A and an other reward Y for my server B. 

This PR add for the user the ability to choice on which server the user will receive his reward. 
The user will be able to select from a dropdown the server A to only show sites that give reward for this server. The user then can vote for this site and receive the reward for the selected server. 

Here is an example 
![image](https://user-images.githubusercontent.com/74878280/126628099-58560bf9-a186-4aee-a1c5-f3df7bddbe9c.png)

If there is only rewards for one server, the dropdown one be displayed 
![image](https://user-images.githubusercontent.com/74878280/126628193-051073ad-b7b2-431d-809f-14974afb1394.png)

You can site an example here https://www.edencraft.fr/vote (need to be logged in)
![ezgif-1-f0e339ca11e6](https://user-images.githubusercontent.com/74878280/126628933-cde319b9-b373-4db3-bb8b-6ec0a26aedab.gif)
