### PR TITLE
Add DiscordTop vote verification

### DIFF
--- a/src/Verification/VoteChecker.php
+++ b/src/Verification/VoteChecker.php
@@ -88,6 +88,14 @@ class VoteChecker
             ->requireKey('api_key')
             ->verifyByValue(1));
 
+        $this->register(VoteVerifier::for('discordtop.net')
+            ->setApiUrl('https://api.discordtop.net/v7/check-vote?external_id={name}')
+            ->requireKey('api_key')
+            ->transformRequest(function (PendingRequest $request, User $user, Site $site) {
+                return $request->withToken($site->verification_key);
+            })
+            ->verifyByJson('has_voted', true));
+
         $listForge = [
             'gmod-servers.com', 'ark-servers.net', 'rust-servers.net',
             'tf2-servers.com', '7daystodie-servers.com', 'unturned-servers.net',


### PR DESCRIPTION
Adds native support for DiscordTop vote verification using the VoteVerifier system.
This integration uses the official API endpoint and the recommended Authorization: Bearer <token> authentication method, ensuring a secure and modern implementation.

Key features included:

- New discordtop.net verifier registration
- Secure authentication via transformRequest() and Bearer token
- Clean API call to the /v7/check-vote endpoint
- JSON-based verification using the has_voted field
- Full compatibility with the Vote plugin’s architecture

This PR improves interoperability with external Discord vote platforms and aligns the plugin with current best practices for third-party API integrations.