### PR TITLE
fix: prevent Vote created event from stopping observer chain

### DIFF
--- a/src/Models/Vote.php
+++ b/src/Models/Vote.php
@@ -54,7 +54,9 @@ class Vote extends Model
 
     protected static function booted(): void
     {
-        static::created(fn () => Cache::forget('vote.count.month'));
+        static::created(function () {
+            Cache::forget('vote.count.month');
+        });
     }
 
     public function user()


### PR DESCRIPTION
Cache::forget() returns false when key doesn't exist, and arrow function implicitly returned it. Laravel's dispatcher breaks the listener loop on false, silently blocking all subsequent observers (including RewardShowers VoteLoyalty increment).