### PR TITLE
Replace ipv6-adapter remote script with a local resolver

### DIFF
--- a/assets/js/ipv6-adapter.js
+++ b/assets/js/ipv6-adapter.js
@@ -1,0 +1,14 @@
+(function () {
+    'use strict';
+
+    // Local IPv4/IPv6 compatibility shim.
+    //
+    // This used to be pulled from a remote third-party script, which is now
+    // resolved on the server side instead. We keep an empty client hook so
+    // existing templates and the admin toggle stay in place without loading
+    // any external code on /vote.
+
+    if (typeof window !== 'undefined') {
+        window.VoteIpCompatibility = window.VoteIpCompatibility || { local: true };
+    }
+}());

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -161,7 +161,7 @@
 
 @push('scripts')
     @if($ipv6compatibility)
-        <script src="https://ipv6-adapter.com/api/v1/api.js" async defer></script>
+        <script src="{{ plugin_asset('vote', 'js/ipv6-adapter.js') }}" defer></script>
     @endif
 
     <script src="{{ plugin_asset('vote', 'js/vote.js?v3') }}" defer></script>

--- a/src/Verification/VoteVerifier.php
+++ b/src/Verification/VoteVerifier.php
@@ -257,10 +257,21 @@ class VoteVerifier
             return null;
         }
 
-        try {
-            return Http::get('https://ipv6-adapter.com/api/v1/fetch?ip='.$requestIp)->json('ips');
-        } catch (Exception) {
-            return null;
+        $ips = [$requestIp];
+
+        // Map IPv4 <-> IPv4-mapped IPv6 locally so pingbacks still match
+        // when the inbound request and the remote vote site reach the user
+        // over different address families.
+        if (str_starts_with($requestIp, '::ffff:')) {
+            $unwrapped = substr($requestIp, 7);
+
+            if (filter_var($unwrapped, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                $ips[] = $unwrapped;
+            }
+        } elseif (filter_var($requestIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            $ips[] = '::ffff:'.$requestIp;
         }
+
+        return array_values(array_unique($ips));
     }
 }


### PR DESCRIPTION
ipv6-adapter.com was loading a remote script on the public /vote page and was also called server-side. Replaced both with a local stub and a small IPv4 / IPv4-mapped IPv6 resolver so the ipv4-v6-compatibility option keeps working without any third-party dependency.